### PR TITLE
Old oop style parallel support

### DIFF
--- a/src/@dates/dates.m
+++ b/src/@dates/dates.m
@@ -70,7 +70,13 @@ if nargin>0 && ischar(varargin{1}) && isequal(varargin{1},'initialize')
     return
 end
 
-dd = evalin('base','emptydatesobject');
+try
+    dd = evalin('base','emptydatesobject');
+catch
+    dd = struct('ndat', 0, 'freq', NaN(0), 'time', NaN(0,2));
+    dd = class(dd,'dates');
+    assignin('base','emptydatesobject',dd);
+end
 
 if isequal(nargin, 0)
     % Return an empty dates obect

--- a/src/@dates/dates.m
+++ b/src/@dates/dates.m
@@ -102,6 +102,12 @@ if all(cellfun(@isstringdate,varargin))
     return
 end
 
+if isequal(nargin,1) && isstruct(varargin{1})
+    dd = varargin{1};
+    dd = class(dd,'dates');
+    return
+end
+
 if isequal(nargin,1) && isfreq(varargin{1})
     % Instantiate an empty dates object (only set frequency)
     if ischar(varargin{1})


### PR DESCRIPTION
Contains two improvements.

 1. Supports initialization from a structure, which is necessary for one work round to this issue: https://github.com/DynareTeam/dynare/issues/1400 .
 2. Ensures the emptydatesobject is always initialized. Again this is necessary in a parallel context as initialize might not have been called on parallel workers. (For example, the pool may have collapsed and restarted.)

See also my related pull requests to dynare and dseries.